### PR TITLE
Add reset counts button

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -98,6 +98,9 @@ webrtc_streamer(key="emotion", mode=WebRtcMode.SENDRECV,
                media_stream_constraints={"video": True, "audio": False})
 
 st.header("Emotion Distribution")
+if st.button("Reset Counts"):
+    for key in st.session_state.emotion_counts:
+        st.session_state.emotion_counts[key] = 0
 counts = st.session_state.emotion_counts
 source = pd.DataFrame({"emotion": list(counts.keys()), "count": list(counts.values())})
 chart = alt.Chart(source).mark_bar().encode(x="emotion", y="count", color="emotion")


### PR DESCRIPTION
## Summary
- add optional 'Reset Counts' button to Streamlit app

## Testing
- `python -m py_compile app/streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684081315b38832a9f04f85fdcbf9617